### PR TITLE
ci: update go versions in build workflow to 1.23.6 and 1.24.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,20 +65,19 @@ jobs:
       # required to push to GHCR
       packages: write
     env:
-      LATEST_CURRENT: 1.23.0
-      LATEST_PREVIOUS: 1.22.6
+      LATEST_CURRENT: 1.24.0
+      LATEST_PREVIOUS: 1.23.6
     strategy:
       fail-fast: false
       matrix:
         go_version:
-          - 1.22.0
-          - 1.22.1
-          - 1.22.2
-          - 1.22.3
-          - 1.22.4
-          - 1.22.5
-          - 1.22.6
           - 1.23.0
+          - 1.23.1
+          - 1.23.2
+          - 1.23.3
+          - 1.23.4
+          - 1.23.5
+          - 1.24.0
     steps:
       -
         name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         go_version:
-          - 1.23.0
-          - 1.22.6
+          - 1.24.0
+          - 1.23.6
         example:
           - c
           - cpp
@@ -35,7 +35,7 @@ jobs:
           - jq
         include:
           - target: artifact-all
-          - go_version: 1.23.0
+          - go_version: 1.24.0
             example: all
             target: image
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG UBUNTU_VERSION="20.04"
-ARG GO_VERSION="1.23.0"
+ARG GO_VERSION="1.24.0"
 
 FROM ubuntu:${UBUNTU_VERSION} AS base
 RUN export DEBIAN_FRONTEND="noninteractive" \


### PR DESCRIPTION
Add go 1.24.0, 1.23.x, drop 1.21.x.