### PR TITLE
update to ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 # syntax=docker/dockerfile:1
 
-ARG UBUNTU_VERSION="20.04"
+ARG UBUNTU_VERSION="24.04"
 ARG GO_VERSION="1.26.3"
 
 FROM ubuntu:${UBUNTU_VERSION} AS base
 RUN export DEBIAN_FRONTEND="noninteractive" \
   && apt-get update \
-  && apt-get install --no-install-recommends -y software-properties-common \
-  && add-apt-repository ppa:git-core/ppa \
-  && apt-get update \
   && apt-get install --no-install-recommends -y \
     bash \
     binutils \
+    bzip2 \
     ca-certificates \
     clang \
     curl \
@@ -60,6 +58,6 @@ ARG GO_VERSION
 ENV GO_VERSION=${GO_VERSION}
 
 ENV PATH="$GOPATH/bin:/usr/local/go/bin:/osxcross/bin:$PATH"
-ENV LD_LIBRARY_PATH="/osxcross/lib:$LD_LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="/osxcross/lib"
 COPY rootfs /
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ image to build against the `darwin` platform with CGO.
 Using the `COPY` command:
 
 ```dockerfile
-FROM --platform=$BUILDPLATFORM crazymax/osxcross:11.3 AS osxcross
+FROM --platform=$BUILDPLATFORM crazymax/osxcross:26.1 AS osxcross
 FROM base AS build
 COPY --from=osxcross /osxcross /osxcross
 ARG TARGETPLATFORM
@@ -200,7 +200,7 @@ RUN --mount=type=bind,source=. \
 Or a `RUN` mount:
 
 ```dockerfile
-FROM --platform=$BUILDPLATFORM crazymax/osxcross:11.3 AS osxcross
+FROM --platform=$BUILDPLATFORM crazymax/osxcross:26.1 AS osxcross
 FROM base AS build
 ARG TARGETPLATFORM
 RUN --mount=type=bind,source=. \

--- a/examples/c/Dockerfile
+++ b/examples/c/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 FROM --platform=$BUILDPLATFORM crazymax/goxx:latest AS goxx
-FROM --platform=$BUILDPLATFORM crazymax/osxcross:11.3 AS osxcross
+FROM --platform=$BUILDPLATFORM crazymax/osxcross:26.1 AS osxcross
 
 FROM goxx AS base
 ENV GO111MODULE=auto

--- a/examples/cpp/Dockerfile
+++ b/examples/cpp/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 FROM --platform=$BUILDPLATFORM crazymax/goxx:latest AS goxx
-FROM --platform=$BUILDPLATFORM crazymax/osxcross:11.3 AS osxcross
+FROM --platform=$BUILDPLATFORM crazymax/osxcross:26.1 AS osxcross
 
 FROM goxx AS base
 ENV GO111MODULE=auto

--- a/examples/gorm/Dockerfile
+++ b/examples/gorm/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 FROM --platform=$BUILDPLATFORM crazymax/goxx:latest AS goxx
-FROM --platform=$BUILDPLATFORM crazymax/osxcross:11.3 AS osxcross
+FROM --platform=$BUILDPLATFORM crazymax/osxcross:26.1 AS osxcross
 
 FROM goxx AS base
 ENV GO111MODULE=auto

--- a/examples/jq/Dockerfile
+++ b/examples/jq/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 FROM --platform=$BUILDPLATFORM crazymax/goxx:latest AS goxx
-FROM --platform=$BUILDPLATFORM crazymax/osxcross:11.3 AS osxcross
+FROM --platform=$BUILDPLATFORM crazymax/osxcross:26.1 AS osxcross
 
 FROM goxx AS base
 COPY --from=osxcross /osxcross /osxcross

--- a/rootfs/usr/local/bin/goxx-apt-get
+++ b/rootfs/usr/local/bin/goxx-apt-get
@@ -26,9 +26,18 @@ EOL
 }
 
 if [ -z "${GOXX_SKIP_APT_PORTS}" ]; then
+  rm -f /etc/apt/sources.list.d/ubuntu.sources
   case "${GOXX_HOSTARCH}" in
   amd64 | i386)
-      setaptsources "/etc/apt/sources.list" "$GOXX_HOSTARCH" "http://archive.ubuntu.com/ubuntu/" "http://security.ubuntu.com/ubuntu/"
+      aptarch="$GOXX_HOSTARCH"
+      if [ "$GOOS" = "linux" ] && [ "$GOXX_CROSS" = "1" ]; then
+        case "${GOXX_DEBARCH}" in
+          amd64 | i386)
+            aptarch="$GOXX_HOSTARCH,$GOXX_DEBARCH"
+            ;;
+        esac
+      fi
+      setaptsources "/etc/apt/sources.list" "$aptarch" "http://archive.ubuntu.com/ubuntu/" "http://security.ubuntu.com/ubuntu/"
       ;;
     *)
       setaptsources "/etc/apt/sources.list" "$GOXX_HOSTARCH" "http://ports.ubuntu.com/ubuntu-ports/" "http://ports.ubuntu.com/ubuntu-ports/"
@@ -37,7 +46,10 @@ if [ -z "${GOXX_SKIP_APT_PORTS}" ]; then
   if [ "$GOOS" = "linux" ] && [ "$GOXX_CROSS" = "1" ]; then
     case "${GOXX_DEBARCH}" in
       amd64 | i386)
-        setaptsources "/etc/apt/sources.list.d/port-$GOXX_DEBARCH.list" "$GOXX_DEBARCH" "http://archive.ubuntu.com/ubuntu/" "http://security.ubuntu.com/ubuntu/"
+        case "${GOXX_HOSTARCH}" in
+          amd64 | i386) ;;
+          *) setaptsources "/etc/apt/sources.list.d/port-$GOXX_DEBARCH.list" "$GOXX_DEBARCH" "http://archive.ubuntu.com/ubuntu/" "http://security.ubuntu.com/ubuntu/" ;;
+        esac
         ;;
       *)
         setaptsources "/etc/apt/sources.list.d/port-$GOXX_DEBARCH.list" "$GOXX_DEBARCH" "http://ports.ubuntu.com/ubuntu-ports/" "http://ports.ubuntu.com/ubuntu-ports/"

--- a/rootfs/usr/local/bin/goxx-env
+++ b/rootfs/usr/local/bin/goxx-env
@@ -231,8 +231,8 @@ case "$GOARCH" in
         GOXX_TRIPLE="armv7-w64-mingw32"
       fi
       if [ "$CGO_ENABLED" = "1" ]; then
-        CGO_CFLAGS="-march=armv7-a -fPIC"
-        CGO_CXXFLAGS="-march=armv7-a -fPIC"
+        CGO_CFLAGS="-march=armv7-a -mfpu=vfpv3-d16 -fPIC"
+        CGO_CXXFLAGS="-march=armv7-a -mfpu=vfpv3-d16 -fPIC"
       fi
       ;;
     *)


### PR DESCRIPTION
The base image now uses Ubuntu 24.04, the obsolete Git PPA setup was removed, `LD_LIBRARY_PATH` no longer references an undefined value, and `goxx-apt-get` removes Ubuntu's default Deb822 source before writing architecture-filtered apt sources. The macOS examples and documentation now use osxcross 26.1.