### PR TITLE
preserve host packages in goxx-apt-get

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ Image: crazymax/goxx:latest
 | `windows/386`        | `i686-w64-mingw32-gcc`         | `i686-w64-mingw32-g++`         |
 | `windows/amd64`      | `x86_64-w64-mingw32-gcc`       | `x86_64-w64-mingw32-g++`       |
 
+> [!NOTE]
 > ¹ `darwin*` platform requires the [MacOSX cross toolchain](#macosx-cross-toolchain)
 > if using CGO.
->
+
+> [!NOTE]
 > ² compilers for `mips*` archs are not available with `linux/arm64` image.
 
 ## Usage
@@ -121,7 +123,8 @@ ENTRYPOINT [ "/hello" ]
   of buildx so [`goxx-*` wrappers](#wrappers) will be able to automatically
   build against the right platform.
 
-> More details about multi-platform builds in this [blog post](https://medium.com/@tonistiigi/faster-multi-platform-builds-dockerfile-cross-compilation-guide-part-1-ec087c719eaf).
+> [!TIP]
+> More details about multi-platform builds in [docker docs](https://docs.docker.com/build/building/multi-platform/).
 
 Let's run a simple build against the `artifact` target in our Dockerfile:
 
@@ -250,7 +253,8 @@ done
 EOT
 ```
 
-> **Note**: This is not recommended for production use.
+> [!CAUTION]
+> This is not recommended for production use.
 
 ## Contributing
 

--- a/rootfs/usr/local/bin/goxx-apt-get
+++ b/rootfs/usr/local/bin/goxx-apt-get
@@ -124,6 +124,8 @@ for p in ${packages}; do
     n="${p}-${GOXX_DEBARCH}-cross"
   elif [ "${GOOS}" = "linux" ] && [ -n "$(apt-cache madison "${p}:${GOXX_DEBARCH}" 2>/dev/null)" ]; then
     n="${p}:${GOXX_DEBARCH}"
+  elif [ -n "$(apt-cache madison "${p}" 2>/dev/null)" ]; then
+    n=${p}
   else
     continue
   fi


### PR DESCRIPTION
fixes #54 

The package resolver now falls back to the plain package name after checking target-specific package names, cross packages, and target-architecture package qualifiers.